### PR TITLE
docs: self-serve appId quickstart, drop stale "email to register" steps

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -685,7 +685,7 @@ curl -X POST https://intentapiv4.rozo.ai/functions/v1/payment-api \
 ```
 
 **Common Causes:**
-- Invalid `appId` (not registered with Rozo)
+- Missing `appId` (it is required and must be non-empty). You do **not** need to pre-register an `appId` — any namespace string works for basic payments, and only portal-issued prefixes (`wallet_*`, `merchant*`) require an `X-API-Key` header. To try the SDK without signing up, use the public sandbox `appId` `rozoSandbox`. See the **Quickstart** in the [README](../README.md) for how to get a production `appId` + key (self-serve, no approval).
 - Unsupported chain/token combination
 - Amount below minimum ($1 USD)
 - Invalid destination address format
@@ -720,7 +720,7 @@ has been blocked by CORS policy
 ```
 
 **Root Cause:**
-Rozo API has CORS restrictions. Localhost is usually allowed, but some configurations aren't.
+The Rozo payment API responds with `Access-Control-Allow-Origin: *`, so cross-origin requests are not blocked by an allow-list — you do **not** need to register your domain to whitelist CORS. A CORS error in the browser is therefore almost always a local issue (a network proxy/firewall stripping headers, a service worker, or a misconfigured request), not a domain-whitelist requirement.
 
 **Debug Steps:**
 
@@ -763,7 +763,7 @@ module.exports = {
 ```
 
 **For production:**
-Register your domain with Rozo support to whitelist CORS.
+No domain registration is required — the API allows all origins (`Access-Control-Allow-Origin: *`). If you still see CORS errors in production, check for an intermediary (CDN/WAF/proxy) stripping CORS headers, or call the API from your backend instead of the browser.
 
 ---
 

--- a/packages/connectkit/README.md
+++ b/packages/connectkit/README.md
@@ -3,6 +3,79 @@
 Rozo Intent Pay enables seamless crypto payments for your app.
 Onboard users from any chain, any coin into your app with one click and maximize your conversion.
 
+## Quickstart — Get your `appId` and run a payment
+
+Every payment takes a required `appId`. **You do not need to email anyone or wait for approval to get one** — `appId` is a namespace string you choose to group your transactions in the Rozo dashboard.
+
+There are two ways to get going:
+
+### 1. Try it now with the public sandbox `appId`
+
+Use the shared sandbox `appId` `rozoSandbox` to run the SDK end-to-end immediately, no signup required:
+
+```tsx
+"use client";
+import { RozoPayButton } from "@rozoai/intent-pay";
+
+<RozoPayButton
+  appId="rozoSandbox"          // public shared sandbox — testing only
+  toChain={8453}               // Base
+  toAddress="0xRecipient..."   // your receiving address
+  toToken="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" // USDC on Base
+  toUnits="1"                  // display amount, in USDC (string, not base units)
+  intent="Pay"
+  preferredSymbol={["USDC", "USDT"]}
+  onPaymentCompleted={(e) => console.log("done", e.paymentId)}
+/>
+```
+
+> `rozoSandbox` is a **shared, public** sandbox namespace meant only for trying the SDK out. **Do not use it in production** — transactions under it are co-mingled with everyone else's test traffic and the namespace may be cleared at any time. Switch to your own `appId` (below) before you ship.
+
+### 2. Get a production `appId` + API key (self-serve, no approval)
+
+When you're ready for production — your own namespace, webhook events, branded checkout, and API-key auth — self-register through the Rozo merchant portal. It's a 2-minute, fully self-serve flow (email OTP → pick a slug → done). No human approval step:
+
+1. Open the [Rozo Partners portal](https://partners.rozo.ai/) and enter your email; you'll get a 6-digit code.
+2. Choose **"Wallet (Dapp developer)"** as the account type (developers don't need to provide a settlement wallet — that's only for merchants).
+3. Pick a slug (e.g. `coffee-studio`). The portal derives your `appId` automatically: `wallet_<slug>` (or `merchant_<slug>` for merchant accounts).
+4. You're dropped into **Settings → API Keys**, where you issue your first `rz_live_...` API key (shown once — copy it). Pass it as the `X-API-Key` header when your `appId` uses a portal-issued prefix.
+
+That's the whole loop — no email to support, no domain whitelisting request.
+
+### Minimal end-to-end (provider → button → result)
+
+```bash
+npm install @rozoai/intent-pay @rozoai/intent-common \
+  @tanstack/react-query wagmi viem \
+  @creit.tech/stellar-wallets-kit @stellar/stellar-sdk
+```
+
+```tsx
+// providers.tsx — wrap your app once (see docs/PROVIDER_SETUP.md for SSR details)
+"use client";
+import { getDefaultConfig, RozoPayProvider } from "@rozoai/intent-pay";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+import { createConfig, WagmiProvider } from "wagmi";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [config] = useState(() =>
+    createConfig(getDefaultConfig({ appName: "Your App", ssr: true })));
+  const [qc] = useState(() => new QueryClient());
+  return (
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={qc}>
+        <RozoPayProvider>{children}</RozoPayProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+}
+```
+
+Then drop a `<RozoPayButton appId="rozoSandbox" ... />` (snippet above) anywhere inside the provider and read the result from `onPaymentCompleted`, or poll with the `useRozoPayStatus()` hook / `getPayment(id)` on your backend.
+
+> **Result truth lives on the backend.** Treat `onPaymentCompleted` as a UI hint and confirm settlement server-side (webhook or `getPayment`) before fulfilling.
+
 ## Features
 
 - 🌱 Cross-chain payments from 1000+ tokens in under 1 minute.
@@ -55,7 +128,7 @@ Clone the repository and build the SDK in `dev` mode:
 
 ```sh
 git clone https://github.com/RozoAI/intent-pay.git
-cd pay/packages/connectkit
+cd intent-pay/packages/connectkit
 pnpm i
 pnpm run dev
 ```
@@ -63,7 +136,7 @@ pnpm run dev
 The rollup bundler will now watch file changes in the background. Try using one of the examples for testing:
 
 ```sh
-cd examples/nextjs
+cd examples/nextjs-app
 pnpm i
 pnpm run dev
 ```


### PR DESCRIPTION
## What

Docs-only fix. The SDK is already self-serve, but the docs implied developers must email Rozo support to get an `appId` approved — which broke the "self-serve integration" promise.

In reality `appId` is a **soft-enforce prefix model**: any string that isn't a `wallet_*` / `merchant*` prefix (e.g. a developer's own namespace) is accepted without an API key. No manual approval is needed to start integrating.

## Changes

- **README** — new **"Quickstart — Get your appId"** section:
  - `appId` is a developer-chosen namespace string (no pre-registration, no email approval).
  - Public sandbox `appId` **`rozoSandbox`** to run end-to-end immediately (shared / test-only / may be reset).
  - Copy-paste happy path (`npm i` → `RozoPayProvider` → `<RozoPayButton appId="rozoSandbox" ... />` → `onPaymentCompleted`).
  - 4-step self-serve flow for a production `appId` + `rz_live_` API key via the [Rozo Partners portal](https://partners.rozo.ai/) (email OTP → pick a slug → key issued, zero human approval).
  - Fixed two stale paths (install dir + nextjs example).
- **TROUBLESHOOTING** — removed outdated "appId not registered" / "register your domain with Rozo support to whitelist CORS" guidance (CORS is `*`; legacy appIds need no key).

## Why it's safe

Documentation only — no SDK / runtime / backend behavior change. Stellar support is unaffected (decoupled from the appId path).

## Follow-up (maintainer)

Because npm shows the published README, a patch release (e.g. `0.1.27`) is needed for the npm package page to reflect these docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)