### PR TITLE
docs: add bridge live demo link with UTM attribution to READMEs

### DIFF
--- a/packages/connectkit/README.md
+++ b/packages/connectkit/README.md
@@ -133,8 +133,6 @@ Check out our Demo Page at [demo.rozo.ai](https://demo.rozo.ai/)
 
 You can also try the intent-based bridge built with this SDK at [intents.rozo.ai/bridge](https://intents.rozo.ai/bridge?utm_source=npm&utm_medium=readme).
 
-You can also try the intent-based bridge built with this SDK at [intents.rozo.ai/bridge](https://intents.rozo.ai/bridge?utm_source=github&utm_medium=readme).
-
 ### Local Development
 
 Clone the repository and build the SDK in `dev` mode:

--- a/packages/connectkit/README.md
+++ b/packages/connectkit/README.md
@@ -131,6 +131,10 @@ You can also check out the [Next.js example app](https://github.com/RozoAI/inten
 
 Check out our Demo Page at [demo.rozo.ai](https://demo.rozo.ai/)
 
+You can also try the intent-based bridge built with this SDK at [intents.rozo.ai/bridge](https://intents.rozo.ai/bridge?utm_source=npm&utm_medium=readme).
+
+You can also try the intent-based bridge built with this SDK at [intents.rozo.ai/bridge](https://intents.rozo.ai/bridge?utm_source=github&utm_medium=readme).
+
 ### Local Development
 
 Clone the repository and build the SDK in `dev` mode:


### PR DESCRIPTION
Adds a link to the live intent-based bridge (intents.rozo.ai/bridge) in the Demo section of the package README, carrying `utm_source=npm&utm_medium=readme` so traffic and paid conversions can be attributed by channel. The bridge frontend already captures `utm_*` into PostHog and payment metadata.

Note: the repo root `README.md` is a symlink to `packages/connectkit/README.md`, so this single link covers both the GitHub repo page and the npm package page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)