### PR TITLE
feat: support MugglePay SDK branding

### DIFF
--- a/packages/connectkit/README.md
+++ b/packages/connectkit/README.md
@@ -79,6 +79,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 Then drop a `<RozoPayButton appId="rozoSandbox" ... />` (snippet above) anywhere inside the provider and read the result from `onPaymentCompleted`, or poll with the `useRozoPayStatus()` hook / `getPayment(id)` on your backend.
 
+To show MugglePay branding in the modal footer, set the provider option:
+
+```tsx
+<RozoPayProvider options={{ poweredBy: "Mugglepay" }}>
+  {children}
+</RozoPayProvider>
+```
+
 > **Embedding inside a wallet's in-app browser (Base App, MetaMask, Phantom)?** `ssr: true` alone does not eliminate the auto-connect flash on first load — you also need cookie-persisted `initialState`. See [PROVIDER_SETUP.md § Minimizing the Wallet Reconnect Flash](../../docs/PROVIDER_SETUP.md#minimizing-the-wallet-reconnect-flash-in-app-browsers) (required, not optional, for this use case).
 
 > **Result truth lives on the backend.** Treat `onPaymentCompleted` as a UI hint and confirm settlement server-side (webhook or `getPayment`) before fulfilling.

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rozoai/intent-pay",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": false,
   "description": "Seamless crypto payments. Onboard users from any chain, any coin into your app with one click.",
   "keywords": [

--- a/packages/connectkit/src/components/Common/PoweredByFooter/index.tsx
+++ b/packages/connectkit/src/components/Common/PoweredByFooter/index.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { keyframes } from "styled-components";
 import RozoTextLogo from "../../../assets/rozo-text";
 import { useContactSupport } from "../../../hooks/useContactSupport";
+import { usePayContext } from "../../../hooks/usePayContext";
 import styled from "../../../styles/styled";
 
 const PoweredByFooter = ({
@@ -9,17 +10,28 @@ const PoweredByFooter = ({
   showSupport = true,
 }: { preFilledMessage?: string; showSupport?: boolean } = {}) => {
   const handleContactClick = useContactSupport(preFilledMessage);
+  const context = usePayContext();
+  const poweredBy = context.options?.poweredBy ?? "rozo";
 
   return (
     <>
       <Container>
         <TextButton
           onClick={() => {
-            window.open("http://rozo.ai/", "_blank");
+            window.open(
+              poweredBy === "Mugglepay"
+                ? "https://mugglepay.com/"
+                : "https://rozo.ai/",
+              "_blank",
+            );
           }}
         >
           <span>Powered by</span>
-          <RozoTextLogo height={16} style={{ position: "relative", top: 2 }} />
+          {poweredBy === "Mugglepay" ? (
+            <BrandName>MugglePay</BrandName>
+          ) : (
+            <RozoTextLogo height={16} style={{ position: "relative", top: 2 }} />
+          )}
         </TextButton>
         {showSupport && (
           <TextButton onClick={handleContactClick}>Get help</TextButton>
@@ -86,6 +98,10 @@ const TextButton = styled(motion.button)`
   &.support span {
     animation: ${fadeIn} 300ms ease both;
   }
+`;
+
+const BrandName = styled.span`
+  font-weight: 700;
 `;
 
 const Underline = styled(motion.span)`

--- a/packages/connectkit/src/types.ts
+++ b/packages/connectkit/src/types.ts
@@ -26,6 +26,8 @@ export type { CustomAvatarProps };
 
 /** Global options, across all pay buttons and payments. */
 export type RozoPayContextOptions = {
+  /** Brand shown in the modal footer. Defaults to "rozo". */
+  poweredBy?: "rozo" | "Mugglepay";
   language?: Languages;
   hideBalance?: boolean;
   hideTooltips?: boolean;


### PR DESCRIPTION
## Summary
- add `options.poweredBy = "Mugglepay"` to the SDK provider
- render and link the MugglePay footer brand when selected
- bump `@rozoai/intent-pay` to 0.1.35

## Verification
- connectkit lint passed in pre-commit
- connectkit production build completed (existing upstream ox type warning only)

## Release
After merge, tag `v0.1.35` to publish through the existing release workflow.