### PR TITLE
fix(sdk): guard window.innerWidth against SSR in ScrollArea/SelectToken

### DIFF
--- a/packages/connectkit/src/components/Common/ScrollArea/index.tsx
+++ b/packages/connectkit/src/components/Common/ScrollArea/index.tsx
@@ -41,7 +41,9 @@ export const ScrollArea = ({
   const moreRef = useRef<HTMLDivElement>(null);
 
   const isMobileFormat =
-    isMobile() || window?.innerWidth < defaultTheme.mobileWidth;
+    isMobile() ||
+    (typeof window !== "undefined" &&
+      window.innerWidth < defaultTheme.mobileWidth);
 
   useEffect(() => {
     const el = ref.current;

--- a/packages/connectkit/src/components/Pages/SelectToken/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectToken/index.tsx
@@ -28,7 +28,9 @@ import SelectAnotherMethodButton from "../../Common/SelectAnotherMethodButton";
 export default function SelectToken() {
   const { isMobile } = useIsMobile();
   const isMobileFormat =
-    isMobile || window?.innerWidth < defaultTheme.mobileWidth;
+    isMobile ||
+    (typeof window !== "undefined" &&
+      window.innerWidth < defaultTheme.mobileWidth);
 
   const { paymentState, setRoute } = usePayContext();
   const { tokenMode, tokenModeExplicit, connectedWalletOnly, paymentOptions } = paymentState;


### PR DESCRIPTION
## Summary

Harden two render-time `window.innerWidth` reads in the pay modal against SSR. `window?.innerWidth` (optional chaining) does **not** prevent `ReferenceError: window is not defined` under server-side rendering — optional chaining only short-circuits `null`/`undefined` *values*, not an **undeclared** global. On the server `window` is not declared at all, so evaluating `window?.innerWidth` throws.

## Root cause

`demo.rozo.ai` was returning HTTP 500 on every route (`/`, `/bridge`, `/checkout`, `/deposit`, even `/_not-found`). Vercel runtime logs (project `intent-example`) show:

```
ReferenceError: window is not defined
    at sC (.next/server/chunks/1599.js) digest: 3277775968
```

The **active** production 500 traces to a stale production deployment pinned to an older `master` commit that predated the `isDNTEnabled` SSR guard — current `master` already builds and serves clean 200s locally (verified). That deployment situation is an ops promotion, handled separately.

This PR fixes the **remaining latent instances of the same bug class**. In `ScrollArea` and `SelectToken`:

```ts
isMobile() || window?.innerWidth < defaultTheme.mobileWidth
```

`isMobile()` / `useIsMobile()` return `false` on the server (they read `navigator`), so evaluation falls through to `window?.innerWidth` and throws — crashing the whole page the moment the pay modal renders server-side (any consumer app not using `force-dynamic`, or once these components render on the server path). Same class as the `isDNTEnabled` SSR fix (invoice.rozo.ai incident, 2026-07-13).

## Change

Gate on `typeof window !== "undefined"` before touching `window.innerWidth`:

```ts
isMobile() ||
  (typeof window !== "undefined" &&
    window.innerWidth < defaultTheme.mobileWidth)
```

- `packages/connectkit/src/components/Common/ScrollArea/index.tsx`
- `packages/connectkit/src/components/Pages/SelectToken/index.tsx`

Browser behavior is unchanged; the server returns a safe `false`.

## Verification

- `tsc --noEmit` on `packages/connectkit` — no errors in edited files.
- lint-staged (`pnpm run lint`) passed on both files.
- Isolated SSR repro (no `window` global): the old `window?.innerWidth` pattern throws `ReferenceError: window is not defined`; the new `typeof window` pattern returns `false` with no throw.
- Full `next build` + `next start` of `examples/nextjs-app` on current `master`: `/ → 307`, `/bridge → 200`, `/checkout → 200`, `/deposit → 200`, zero SSR errors in server logs.

## Scope

Minimal — only the two unguarded render-time `window.innerWidth` reads. No SDK core/API/payment logic touched. `wallets.ts` `window?.trustWallet` is already behind a `typeof window` guard and needs no change.
