### PR TITLE
fix: Phantom in-app browser race condition + CheckoutMode improvements

### DIFF
--- a/examples/nextjs-app/components/CheckoutMode.tsx
+++ b/examples/nextjs-app/components/CheckoutMode.tsx
@@ -239,7 +239,7 @@ export function CheckoutMode() {
                       {
                         name: "MetaMask",
                         icon: <WalletMetamask size={40} variant="branded" />,
-                        href: `https://metamask.app.link/dapp/${encoded}`,
+                        href: `https://link.metamask.io/dapp/${encoded}`,
                       },
                       {
                         name: "Phantom",

--- a/examples/nextjs-app/components/CheckoutMode.tsx
+++ b/examples/nextjs-app/components/CheckoutMode.tsx
@@ -7,7 +7,8 @@ import { useSharedConfig } from "@/hooks/useSharedConfig"
 import { generateCheckoutSnippet } from "@/lib/snippets"
 import { createPayment } from "@rozoai/intent-common"
 import { RozoPayButton } from "@rozoai/intent-pay"
-import { useCallback, useEffect, useId, useMemo, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { CodeSnippet } from "./CodeSnippet"
 import { EventLog, type LogEntry } from "./EventLog"
 import { ModeDescription } from "./ModeDescription"
@@ -17,6 +18,7 @@ import { PreviewPane } from "./PreviewPane"
 const APP_ID = "rozoDemo"
 
 export function CheckoutMode() {
+  const searchParams = useSearchParams()
   const [config, setConfig, hydrated] = useSharedConfig()
   const [pending, setPending] = useState(config)
   const [paymentId, setPaymentId] = useState<string | null>(null)
@@ -24,7 +26,34 @@ export function CheckoutMode() {
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [logs, setLogs] = useState<LogEntry[]>([])
+  const showRef = useRef<(() => void) | null>(null)
+  const hasAutoOpened = useRef(false)
   const uid = useId()
+
+  // Read paymentId from URL and set it, then clean up URL
+  useEffect(() => {
+    const urlPaymentId = searchParams.get("paymentId")
+    if (urlPaymentId && !paymentId) {
+      setPaymentId(urlPaymentId)
+      // Clean up URL to prevent re-triggering on refresh
+      const url = new URL(window.location.href)
+      url.searchParams.delete("paymentId")
+      window.history.replaceState({}, "", url.toString())
+    }
+  }, [searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-open modal when paymentId is set from URL
+  useEffect(() => {
+    if (paymentId && !hasAutoOpened.current) {
+      hasAutoOpened.current = true
+      // Small delay to ensure RozoPayButton.Custom is mounted
+      const timer = setTimeout(() => {
+        showRef.current?.()
+      }, 100)
+      return () => clearTimeout(timer)
+    }
+  }, [paymentId])
+
   // sync pending when storage hydrates
   useEffect(() => {
     if (hydrated) setPending(config)
@@ -172,11 +201,14 @@ export function CheckoutMode() {
             onPaymentCompleted={(e) => addLog("completed", e)}
             onPayoutCompleted={(e) => addLog("payout", e)}
           >
-            {({ show }) => (
-              <Button onClick={show} size="lg" className="min-w-40">
-                Pay Now
-              </Button>
-            )}
+            {({ show }) => {
+              showRef.current = show
+              return (
+                <Button onClick={show} size="lg" className="min-w-40">
+                  Pay Now
+                </Button>
+              )
+            }}
           </RozoPayButton.Custom>
           <div className="flex flex-col items-center gap-1.5">
             <p className="max-w-md text-center font-mono text-xs break-all text-muted-foreground">

--- a/examples/nextjs-app/components/CheckoutMode.tsx
+++ b/examples/nextjs-app/components/CheckoutMode.tsx
@@ -232,7 +232,7 @@ export function CheckoutMode() {
                 {isMounted &&
                   (() => {
                     // ponytail: computed once, reused by all wallet hrefs
-                    const payUrl = `${window.location.origin}?paymentId=${paymentId}`
+                    const payUrl = `${window.location.origin}/checkout?paymentId=${paymentId}`
                     const encoded = encodeURIComponent(payUrl)
                     const origin = encodeURIComponent(window.location.origin)
                     const wallets = [

--- a/examples/nextjs-app/components/CheckoutMode.tsx
+++ b/examples/nextjs-app/components/CheckoutMode.tsx
@@ -7,6 +7,13 @@ import { useSharedConfig } from "@/hooks/useSharedConfig"
 import { generateCheckoutSnippet } from "@/lib/snippets"
 import { createPayment } from "@rozoai/intent-common"
 import { RozoPayButton } from "@rozoai/intent-pay"
+import {
+  WalletMetamask,
+  WalletPhantom,
+  WalletTrust,
+  WalletCoinbase,
+  WalletOkx,
+} from "@web3icons/react"
 import { useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { CodeSnippet } from "./CodeSnippet"
@@ -28,7 +35,12 @@ export function CheckoutMode() {
   const [logs, setLogs] = useState<LogEntry[]>([])
   const showRef = useRef<(() => void) | null>(null)
   const hasAutoOpened = useRef(false)
+  const [isMounted, setIsMounted] = useState(false)
   const uid = useId()
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
 
   // Read paymentId from URL and set it, then clean up URL
   useEffect(() => {
@@ -210,10 +222,63 @@ export function CheckoutMode() {
               )
             }}
           </RozoPayButton.Custom>
-          <div className="flex flex-col items-center gap-1.5">
+          <div className="flex flex-col items-center gap-3">
             <p className="max-w-md text-center font-mono text-xs break-all text-muted-foreground">
               Payment ID: {paymentId}
             </p>
+            <div className="flex flex-col items-center gap-2">
+              <p className="text-xs text-muted-foreground">Open in wallet</p>
+              <div className="flex gap-3">
+                {isMounted &&
+                  (() => {
+                    // ponytail: computed once, reused by all wallet hrefs
+                    const payUrl = `${window.location.origin}?paymentId=${paymentId}`
+                    const encoded = encodeURIComponent(payUrl)
+                    const origin = encodeURIComponent(window.location.origin)
+                    const wallets = [
+                      {
+                        name: "MetaMask",
+                        icon: <WalletMetamask size={40} variant="branded" />,
+                        href: `https://metamask.app.link/dapp/${encoded}`,
+                      },
+                      {
+                        name: "Phantom",
+                        icon: <WalletPhantom size={40} variant="branded" />,
+                        href: `https://phantom.app/ul/browse/${encoded}?ref=${origin}`,
+                      },
+                      {
+                        name: "Trust",
+                        icon: <WalletTrust size={40} variant="branded" />,
+                        href: `trust://open_url?coin_id=60&url=${encoded}`,
+                      },
+                      {
+                        name: "Coinbase",
+                        icon: <WalletCoinbase size={40} variant="branded" />,
+                        href: `cbwallet://dapp?url=${encoded}`,
+                      },
+                      {
+                        name: "OKX",
+                        icon: <WalletOkx size={40} variant="branded" />,
+                        href: `okx://wallet/dapp/url?dappUrl=${encoded}`,
+                      },
+                    ]
+                    return wallets.map((w) => (
+                      <a
+                        key={w.name}
+                        href={w.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex flex-col items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        <div className="flex h-10 w-10 items-center justify-center rounded-xl overflow-hidden">
+                          {w.icon}
+                        </div>
+                        <span className="text-[10px]">{w.name}</span>
+                      </a>
+                    ))
+                  })()}
+              </div>
+            </div>
             <Button
               variant="secondary"
               className="text-muted-foreground"

--- a/examples/nextjs-app/package.json
+++ b/examples/nextjs-app/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
     "@rozoai/intent-common": "0.1.25",
-    "@rozoai/intent-pay": "0.1.37",
+    "@rozoai/intent-pay": "0.1.38-beta.4",
     "@stellar/stellar-sdk": "^14.6.1",
     "@tanstack/react-query": "^5.0.0",
     "class-variance-authority": "^0.7.1",

--- a/examples/nextjs-app/package.json
+++ b/examples/nextjs-app/package.json
@@ -44,6 +44,7 @@
     "@rozoai/intent-pay": "0.1.38-beta.4",
     "@stellar/stellar-sdk": "^14.6.1",
     "@tanstack/react-query": "^5.0.0",
+    "@web3icons/react": "^4.1.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rozoai/intent-pay",
-  "version": "0.1.37",
+  "version": "0.1.38-beta.4",
   "private": false,
   "description": "Seamless crypto payments. Onboard users from any chain, any coin into your app with one click.",
   "keywords": [

--- a/packages/connectkit/src/components/RozoPayModal/index.tsx
+++ b/packages/connectkit/src/components/RozoPayModal/index.tsx
@@ -84,10 +84,10 @@ export const RozoPayModal: React.FC<{
   const autoConnectGate = useAutoConnectGate();
 
   // EVM
-  const { isConnected: isEthConnected, connector, chain, address } = useAccount();
+  const { isConnected: isEthConnected, connector, chain, address, status: ethStatus } = useAccount();
 
   // Solana
-  const { connected: isSolanaConnected, wallet: solanaWallet } = useWallet();
+  const { connected: isSolanaConnected, wallet: solanaWallet, connecting: isSolanaConnecting } = useWallet();
 
   // Stellar
   const { isConnected: isStellarConnected } = useStellar();
@@ -276,6 +276,14 @@ export const RozoPayModal: React.FC<{
     if (!injected) return;
     didForceEvmConnectRef.current = true;
     connect({ connector: injected });
+
+    // Safety: if EVM doesn't connect within 10s (e.g. user rejected the
+    // prompt), clear the flag so the auto-navigate guard unblocks and the
+    // user isn't stuck on SELECT_METHOD.
+    const timer = setTimeout(() => {
+      didForceEvmConnectRef.current = false;
+    }, 10_000);
+    return () => clearTimeout(timer);
   }, [context.open, context.route, context.userDisconnected, isEthConnected, isSolanaConnected, isMobile, solanaWallet, connectors, connect]);
 
   // If the user has a wallet already connected upon opening the modal, go
@@ -295,6 +303,19 @@ export const RozoPayModal: React.FC<{
     // navigated back to SELECT_METHOD from SELECT_TOKEN.
     const isExplicitBackNavigation = context.routeMeta?.event === "click-select-another-method";
     if (isExplicitBackNavigation) return;
+
+    // Direct wallet settling checks — guard against race where isConnected
+    // updates before gateState recomputes
+    if (ethStatus === "reconnecting" || ethStatus === "connecting") return;
+    if (isSolanaConnecting) return;
+    // Note: Stellar doesn't expose a connecting state yet
+
+    // Phantom in-app browser: force EVM connect fires on the same commit as
+    // Solana auto-connect, but wagmi status is still "disconnected" (connect()
+    // is async). Without this guard, auto-navigate sees Solana-only and jumps
+    // to SELECT_TOKEN before EVM finishes connecting. Wait for it to settle;
+    // if it fails, the user can manually select their wallet on SELECT_METHOD.
+    if (didForceEvmConnectRef.current && !isEthConnected) return;
 
     // Readiness gate (wallet settled + order resolved, from FSM).
     // "pass"    → no wallet connected: leave SELECT_METHOD showing tiles.
@@ -369,6 +390,10 @@ export const RozoPayModal: React.FC<{
     address,
     chain?.id,
     connector?.id,
+    ethStatus,
+    isSolanaConnecting,
+    isMobile,
+    disableMobileInjector,
   ]);
 
   // If we're on the connect page and the user successfully connects their
@@ -383,6 +408,9 @@ export const RozoPayModal: React.FC<{
       context.route === ROUTES.CONNECTORS ||
       context.route === ROUTES.MOBILECONNECTORS
     ) {
+      // Wait for connection to fully settle, not just isConnected flag
+      if (ethStatus === "connecting" || ethStatus === "reconnecting") return;
+      
       if (isEthConnected) {
         // Dual-chain connect (e.g. Phantom mobile) just linked both EVM and
         // Solana. Return to the pay page so the user picks which connected
@@ -403,7 +431,7 @@ export const RozoPayModal: React.FC<{
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEthConnected, context.route, connector?.id, chain?.id, address, context.dualChainConnect]);
+  }, [isEthConnected, context.route, connector?.id, chain?.id, address, context.dualChainConnect, ethStatus]);
 
   useEffect(() => setMode(mode), [mode, setMode]);
   useEffect(() => setTheme(theme), [theme, setTheme]);

--- a/packages/connectkit/src/components/RozoPayModal/index.tsx
+++ b/packages/connectkit/src/components/RozoPayModal/index.tsx
@@ -248,7 +248,7 @@ export const RozoPayModal: React.FC<{
   const { isMobile } = useIsMobile();
   const { connect } = useConnect();
   const connectors = useConnectors();
-  const didForceEvmConnectRef = useRef(false);
+  const [didForceEvmConnect, setDidForceEvmConnect] = useState(false);
 
   // On deeplink open, only Solana auto-connects via wallet-standard.
   // EVM needs an explicit connect() — the wallet silently approves it inside
@@ -259,7 +259,7 @@ export const RozoPayModal: React.FC<{
   useEffect(() => {
     if (!context.open) {
       // Reset when modal closes so next open can trigger again
-      didForceEvmConnectRef.current = false;
+      setDidForceEvmConnect(false);
       return;
     }
     if (!isMobile) return;
@@ -267,21 +267,21 @@ export const RozoPayModal: React.FC<{
     if (context.route !== ROUTES.SELECT_METHOD) return;
     if (isEthConnected) return;
     if (!isSolanaConnected) return;
-    if (didForceEvmConnectRef.current) return;
+    if (didForceEvmConnect) return;
     const solanaName = solanaWallet?.adapter.name.toLowerCase();
     if (!solanaName) return;
     const injected = connectors.find(
       (c) => c.type === "injected" && c.name.toLowerCase().includes(solanaName),
     );
     if (!injected) return;
-    didForceEvmConnectRef.current = true;
+    setDidForceEvmConnect(true);
     connect({ connector: injected });
 
     // Safety: if EVM doesn't connect within 10s (e.g. user rejected the
     // prompt), clear the flag so the auto-navigate guard unblocks and the
     // user isn't stuck on SELECT_METHOD.
     const timer = setTimeout(() => {
-      didForceEvmConnectRef.current = false;
+      setDidForceEvmConnect(false);
     }, 10_000);
     return () => clearTimeout(timer);
   }, [context.open, context.route, context.userDisconnected, isEthConnected, isSolanaConnected, isMobile, solanaWallet, connectors, connect]);
@@ -315,7 +315,7 @@ export const RozoPayModal: React.FC<{
     // is async). Without this guard, auto-navigate sees Solana-only and jumps
     // to SELECT_TOKEN before EVM finishes connecting. Wait for it to settle;
     // if it fails, the user can manually select their wallet on SELECT_METHOD.
-    if (didForceEvmConnectRef.current && !isEthConnected) return;
+    if (didForceEvmConnect && !isEthConnected) return;
 
     // Readiness gate (wallet settled + order resolved, from FSM).
     // "pass"    → no wallet connected: leave SELECT_METHOD showing tiles.
@@ -394,6 +394,7 @@ export const RozoPayModal: React.FC<{
     isSolanaConnecting,
     isMobile,
     disableMobileInjector,
+    didForceEvmConnect,
   ]);
 
   // If we're on the connect page and the user successfully connects their

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.101.2(react@18.2.0)
+      '@web3icons/react':
+        specifier: ^4.1.19
+        version: 4.1.19(react@18.2.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4504,6 +4507,14 @@ packages:
 
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
+
+  '@web3icons/common@0.11.48':
+    resolution: {integrity: sha512-n4DyN9fnf94N4XyL/iSRG9RmsgqK28OcYcPtQwj3NM0rs++bIbND4psoP1weRSVrY6wzToIcXD9THWKkHtF7BQ==}
+
+  '@web3icons/react@4.1.19':
+    resolution: {integrity: sha512-und1wyzQ1xvQczXvpfmhM/IK/t8FBaYAfMNojoYHVblirC2j/Mvg8htqXp5EueH99NNc/tcDnaYGNMy3vugUxg==}
+    peerDependencies:
+      react: 18.2.0
 
   '@worldcoin/idkit-core@2.1.0':
     resolution: {integrity: sha512-6MOFcOGqpk3iiW1i25NYmRJ6JUO8KetqS5Ic0l2cqnEEKvjMa/NT1+WTuenjTUF//Mqwy5kWgtVBzUqeyEfQ2g==}
@@ -15554,6 +15565,13 @@ snapshots:
     dependencies:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
+
+  '@web3icons/common@0.11.48': {}
+
+  '@web3icons/react@4.1.19(react@18.2.0)':
+    dependencies:
+      '@web3icons/common': 0.11.48
+      react: 18.2.0
 
   '@worldcoin/idkit-core@2.1.0(@types/react@18.3.31)(react@18.2.0)(typescript@5.5.2)(zod@4.4.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.1.25
         version: 0.1.25(bufferutil@4.1.0)(typescript@5.5.2)(utf-8-validate@6.0.6)
       '@rozoai/intent-pay':
-        specifier: 0.1.37
-        version: 0.1.37(39ffed284c1998b2b4af73ee4d40db80)
+        specifier: 0.1.38-beta.4
+        version: 0.1.38-beta.4(39ffed284c1998b2b4af73ee4d40db80)
       '@stellar/stellar-sdk':
         specifier: ^14.4.3
         version: 14.6.1
@@ -2587,8 +2587,8 @@ packages:
   '@rozoai/intent-common@0.1.25':
     resolution: {integrity: sha512-lxyobse0JWNi3t+MJFElVIR2Qrm8JtXQq8ncXhF16Wud2yVDrHVdUWoAPPSCN/vmO5dbblT/0OGXYKI6IPAAww==}
 
-  '@rozoai/intent-pay@0.1.37':
-    resolution: {integrity: sha512-qCoeG3M/FJR0R1JUWoVknan0tokVqCBrS5kPmmGl3RMDzeix9E8+yM8iQeyuHdykbkWqZkORVfZnVD8iGbwSjw==}
+  '@rozoai/intent-pay@0.1.38-beta.4':
+    resolution: {integrity: sha512-r69vNm66d1XwkCZb/m3DM/2gOekqWuHPpESNG5E1LXxTrFmcfBkgN6uIJeNJbgFfmOmPzA0/diZ6TP1TZyRi8w==}
     engines: {node: '>=12.4'}
     peerDependencies:
       '@creit.tech/stellar-wallets-kit': ^1.9.5
@@ -11963,7 +11963,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@rozoai/intent-pay@0.1.37(39ffed284c1998b2b4af73ee4d40db80)':
+  '@rozoai/intent-pay@0.1.38-beta.4(39ffed284c1998b2b4af73ee4d40db80)':
     dependencies:
       '@creit.tech/stellar-wallets-kit': 1.9.5(62b9aba56a6edcfc5568ca8536dcbed1)
       '@reown/appkit': 1.8.21(@react-native-async-storage/async-storage@1.24.0(react-native@0.86.0(@babel/core@7.29.7)(@types/react@18.3.31)(bufferutil@4.1.0)(react@18.2.0)(utf-8-validate@6.0.6)))(@types/react@18.3.31)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.2.0)(typescript@5.5.2)(use-sync-external-store@1.4.0(react@18.2.0))(utf-8-validate@6.0.6)(zod@4.4.3)


### PR DESCRIPTION
## Summary

Fixes wallet auto-connect race condition in Phantom in-app browser and adds CheckoutMode quality-of-life features.

## Changes

### 1. Fix: Phantom in-app browser race condition (`RozoPayModal/index.tsx`)
- Solana auto-connects via wallet-standard while force EVM connect fires async, causing premature navigation to SELECT_TOKEN before EVM settles
- Added `didForceEvmConnectRef` guard: blocks auto-navigate until forced EVM connect resolves
- Added 10s safety timeout to prevent user being stuck on SELECT_METHOD if EVM connect never resolves (e.g. user rejection)
- Result: Phantom in-app browser now correctly shows SELECT_METHOD with both chain tiles when both wallets connect

### 2. feat: `?paymentId` query param (`CheckoutMode.tsx`)
- Reads `?paymentId=XXX` from URL, sets paymentId, cleans URL via `replaceState`
- Auto-opens RozoPay modal after short mount delay

### 3. feat: Wallet deeplink logos (`CheckoutMode.tsx`)
- Shows MetaMask, Phantom, Trust, Coinbase, OKX wallet icons below payment ID
- Each icon links to the wallet's deeplink with the checkout URL (`/checkout?paymentId=XXX`)
- Uses `@web3icons/react` branded icons

### 4. Version bump
- `@rozoai/intent-pay`: `0.1.38-beta.3` → `0.1.38-beta.4`