### PR TITLE
chore(demo): make Rozo Pay Playground non-indexable

### DIFF
--- a/examples/nextjs-app/app/layout.tsx
+++ b/examples/nextjs-app/app/layout.tsx
@@ -20,6 +20,7 @@ const fontMono = Geist_Mono({ subsets: ["latin"], variable: "--font-mono" });
 export const metadata: Metadata = {
   title: "Rozo Pay Playground",
   description: "Interactive developer playground for @rozoai/intent-pay",
+  robots: { index: false, follow: false },
 };
 
 export default async function RootLayout({

--- a/examples/nextjs-app/app/robots.ts
+++ b/examples/nextjs-app/app/robots.ts
@@ -1,0 +1,7 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", disallow: "/" },
+  };
+}

--- a/examples/nextjs-app/next.config.ts
+++ b/examples/nextjs-app/next.config.ts
@@ -2,6 +2,18 @@ import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@rozoai/intent-pay"],
+  async headers() {
+    return [
+      {
+        source: "/_next/static/:path*",
+        headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+      },
+      {
+        source: "/:path*.css",
+        headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+      },
+    ]
+  },
   webpack: (config) => {
     // Force single wagmi instance across workspace symlink by pointing to the
     // app's own node_modules copy so SDK and app share the same context registry.


### PR DESCRIPTION
## What
demo.rozo.ai is a developer playground with no search value, but its pages had no robots directive and `/_next/static` assets were served without `X-Robots-Tag`, so Google was treating the CSS bundles as index candidates (surfaced in Search Console 2026-07-24).

- `layout.tsx`: add `metadata.robots { index: false, follow: false }`
- `app/robots.ts`: new App Router robots handler → `/robots.txt` = `Disallow: /`
- `next.config.ts`: `headers()` adds `X-Robots-Tag: noindex` to `/_next/static/*` and `*.css` (merged into existing config; `transpilePackages`/`webpack` preserved)

## Safety
- No sitemap added. No bridge/checkout/deposit business logic touched.
- `pnpm build` passes; `/robots.txt` route emits `Disallow: /`.
- codex review: no P0 (three changes complementary, headers regex verified against Next path parser, robots.ts / metadata non-conflicting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)