### PR TITLE
feat(analytics): chain_selected event with is_default on pay-modal chain pick

### DIFF
--- a/packages/connectkit/src/hooks/useTokenOptions.tsx
+++ b/packages/connectkit/src/hooks/useTokenOptions.tsx
@@ -9,8 +9,12 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Option } from "../components/Common/OptionsList";
 import TokenChainLogo from "../components/Common/TokenChainLogo";
 import { ROUTES } from "../constants/routes";
+import { ROZO_EVENTS, RozoEventName } from "../lib/analytics/events";
+import { useAnalytics } from "../provider/AnalyticsProvider";
 import { formatUsd, roundTokenAmount } from "../utils/format";
 import { usePayContext } from "./usePayContext";
+
+type CaptureFn = (event: RozoEventName, properties?: Record<string, unknown>) => void;
 
 /// Gets token options when paying from a connected wallet. Supports both EVM
 /// and Solana tokens. See OptionsList.
@@ -20,6 +24,7 @@ export function useTokenOptions(mode: "evm" | "solana" | "stellar" | "all"): {
   refreshOptions: () => Promise<void>;
 } {
   const { setRoute, paymentState } = usePayContext();
+  const { capture } = useAnalytics();
   const {
     isDepositFlow,
     connectedWalletOnly,
@@ -94,6 +99,7 @@ export function useTokenOptions(mode: "evm" | "solana" | "stellar" | "all"): {
           isDepositFlow,
           setSelectedTokenOption,
           setRoute,
+          capture,
           preferredTokens,
         );
     optionsList.push(...evmOptions);
@@ -110,6 +116,7 @@ export function useTokenOptions(mode: "evm" | "solana" | "stellar" | "all"): {
       isDepositFlow,
       setSelectedSolanaTokenOption,
       setRoute,
+      capture,
       preferredTokens,
     );
     optionsList.push(...solanaOptions);
@@ -127,6 +134,7 @@ export function useTokenOptions(mode: "evm" | "solana" | "stellar" | "all"): {
           isDepositFlow,
           setSelectedStellarTokenOption,
           setRoute,
+          capture,
           preferredTokens,
         );
     optionsList.push(...stellarOptions);
@@ -404,6 +412,7 @@ function getEvmTokenOptions(
   isDepositFlow: boolean,
   setSelectedTokenOption: (option: WalletPaymentOption) => void,
   setRoute: (route: ROUTES, meta?: any) => void,
+  capture: CaptureFn,
   _preferredTokens?: Token[],
 ) {
   return options.map((option) => {
@@ -429,6 +438,12 @@ function getEvmTokenOptions(
         <TokenChainLogo key={getRozoTokenKey(option.balance.token)} token={option.balance.token} />,
       ],
       onClick: () => {
+        capture(ROZO_EVENTS.CHAIN_SELECTED, {
+          chain_id: option.balance.token.chainId,
+          chain_name: getChainName(option.balance.token.chainId),
+          token_symbol: option.balance.token.symbol,
+          is_default: false,
+        });
         setSelectedTokenOption(option);
         const meta = {
           event: "click-token",
@@ -451,6 +466,7 @@ function getSolanaTokenOptions(
   isDepositFlow: boolean,
   setSelectedSolanaTokenOption: (option: WalletPaymentOption) => void,
   setRoute: (route: ROUTES, meta?: any) => void,
+  capture: CaptureFn,
   _preferredTokens?: Token[],
 ) {
   return options.map((option) => {
@@ -474,6 +490,12 @@ function getSolanaTokenOptions(
         <TokenChainLogo key={getRozoTokenKey(option.balance.token)} token={option.balance.token} />,
       ],
       onClick: () => {
+        capture(ROZO_EVENTS.CHAIN_SELECTED, {
+          chain_id: option.balance.token.chainId,
+          chain_name: "Solana",
+          token_symbol: option.balance.token.symbol,
+          is_default: false,
+        });
         setSelectedSolanaTokenOption(option);
         const meta = {
           event: "click-solana-token",
@@ -496,6 +518,7 @@ function getStellarTokenOptions(
   isDepositFlow: boolean,
   setSelectedStellarTokenOption: (option: WalletPaymentOption) => void,
   setRoute: (route: ROUTES, meta?: any) => void,
+  capture: CaptureFn,
   _preferredTokens?: Token[],
 ) {
   return options.map((option) => {
@@ -519,6 +542,12 @@ function getStellarTokenOptions(
         <TokenChainLogo key={getRozoTokenKey(option.balance.token)} token={option.balance.token} />,
       ],
       onClick: () => {
+        capture(ROZO_EVENTS.CHAIN_SELECTED, {
+          chain_id: option.balance.token.chainId,
+          chain_name: "Stellar",
+          token_symbol: option.balance.token.symbol,
+          is_default: false,
+        });
         setSelectedStellarTokenOption(option);
         const meta = {
           event: "click-stellar-token",

--- a/packages/connectkit/src/lib/analytics/events.ts
+++ b/packages/connectkit/src/lib/analytics/events.ts
@@ -6,6 +6,10 @@ export const WALLET_EVENTS = {
 export const PAYMENT_EVENTS = {
   PAYMENT_FLOW_STARTED: "payment_flow_started",
   PAYMENT_METHOD_SELECTED: "payment_method_selected",
+  /** Concrete chain chosen for the payment. Props: chain_id (number|string),
+   * chain_name, token_symbol, is_default (false = user clicked; true = default
+   * chain applied without an explicit user choice). */
+  CHAIN_SELECTED: "chain_selected",
   PAYMENT_QUOTE_REQUESTED: "payment_quote_requested",
   PAYMENT_QUOTE_RECEIVED: "payment_quote_received",
   PAYMENT_QUOTE_FAILED: "payment_quote_failed",


### PR DESCRIPTION
## Why
Analytics gap D3: neither checkout.rozo.ai nor agent.rozo.ai emits a concrete chain-selection event. `payment_method_selected` only carries `field=chain` with coarse values (evm/solana/stellar), and the backend defaults `source_chain_id` to Base when nothing is selected — so `source_chain_id=8453` in the data cannot distinguish "user picked Base" from "user picked nothing".

## What
- New catalog event `PAYMENT_EVENTS.CHAIN_SELECTED = "chain_selected"` (`packages/connectkit/src/lib/analytics/events.ts`)
- `useTokenOptions` now captures `chain_selected` in the onClick of every token option (EVM / Solana / Stellar builders) with:
  - `chain_id` — numeric chain id of the picked token
  - `chain_name`
  - `token_symbol`
  - `is_default: false` — an explicit user click
- The `is_default: true` counterpart (default chain applied with no user choice) is emitted by the host app at invoice-creation time (companion PR in rozo-chat-ai).

## Verification
- `pnpm run build` in `packages/connectkit` passes (only pre-existing third-party @reown/appkit type warnings); lint-staged pre-commit passed.

Do not merge/deploy yet — pending review per D3 rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)